### PR TITLE
Helm/Providers/private.yaml file

### DIFF
--- a/private.yaml
+++ b/private.yaml
@@ -1,0 +1,207 @@
+
+## Overriding values for Chart's values.yaml
+## Example values to run Confluent Operator in Private Cloud
+global
+provider:
+  name: private
+  ## if any name which indicates regions
+  ##
+  region: anyregion
+  kubernetes:
+   deployment:
+   ## If kubernetes is deployed in multi zone mode then specify availability-zones as appropriate
+   ## If kubernetes is deployed in single availability zone then specify appropriate values
+   ## For the private cloud, use kubernetes node labels as appropriate
+   zones:
+   - myzones
+  ## more information can be found here
+  ## https://kubernetes.io/docs/concepts/storage/storage-classes/
+  storage:
+  ## Use Retain if you want to persist data after CP cluster has been uninstalled
+  reclaimPolicy: Delete
+  provisioner: <strong>csi.vsphere.vmware.com</strong>
+  parameters: {
+   svstorageclass: default
+  }
+##
+## Docker registry endpoint where Confluent Images are available.
+##
+registry:
+  fqdn: docker.io
+  credential:
+   required: false
+sasl:
+plain:
+  username: test
+  password: test123
+## Zookeeper cluster
+##
+zookeeper:
+name: zookeeper
+replicas: 3
+resources:
+  requests:
+   cpu: 2000m
+   memory: 8Gi
+## Kafka Cluster
+##
+kafka:
+name: kafka
+replicas: 3
+resources:
+  requests:
+   cpu: 2000m
+   memory: 16Gi
+loadBalancer:
+enabled: true
+domain: "cpbu.lab"
+tls:
+  enabled: false
+  fullchain: |-
+  privkey: |-
+  cacerts: |-
+metricReporter:
+  enabled: false
+
+## Connect Cluster
+##
+connect:
+name: connectors
+replicas: 2
+tls:
+  enabled: false
+  ## "" for none, "tls" for mutual auth
+  authentication:
+   type: ""
+  fullchain: |-
+  privkey: |-
+  cacerts: |-
+loadBalancer:
+  enabled: false
+  domain: ""
+dependencies:
+  kafka:
+   bootstrapEndpoint: kafka:9071
+   brokerCount: 3
+  schemaRegistry:
+   enabled: true
+   url: <a href="http://schemaregistry:8081">http://schemaregistry:8081</a>
+## Replicator Connect Cluster
+##
+replicator:
+name: replicator
+replicas: 2
+tls:
+  enabled: false
+  authentication:
+   type: ""
+  fullchain: |-
+  privkey: |-
+  cacerts: |-
+loadBalancer:
+  enabled: false
+  domain: ""
+dependencies:
+  kafka:
+   brokerCount: 3
+   bootstrapEndpoint: kafka:9071
+ 
+##
+## Schema Registry
+##
+schemaregistry:
+name: schemaregistry
+tls:
+  enabled: false
+  authentication:
+   type: ""
+  fullchain: |-
+  privkey: |-
+  cacerts: |-
+loadBalancer:
+  enabled: false
+  domain: ""
+dependencies:
+  kafka:
+  brokerCount: 3
+  bootstrapEndpoint: kafka:9071
+ 
+##
+## KSQL
+##
+ksql:
+name: ksql
+replicas: 2
+tls:
+  enabled: false
+  authentication:
+   type: ""
+  fullchain: |-
+  privkey: |-
+  cacerts: |-
+loadBalancer:
+  enabled: false
+  domain: ""
+dependencies:
+  kafka:
+  brokerCount: 3
+  bootstrapEndpoint: kafka:9071
+  brokerEndpoints: kafka-0.kafka:9071,kafka-1.kafka:9071,kafka-2.kafka:9071
+schemaRegistry:
+  enabled: false
+  tls:
+   enabled: false
+   authentication:
+    type: ""
+  url: http://schemaregistry:8081
+ 
+## Control Center (C3) Resource configuration
+##
+controlcenter:
+name: controlcenter
+license: ""
+##
+## C3 dependencies
+##
+dependencies:
+  c3KafkaCluster:
+   brokerCount: 3
+   bootstrapEndpoint: kafka:9071
+   zookeeper:
+    endpoint: zookeeper:2181
+   connectCluster:
+    enabled: true
+    url: http://connectors:8083
+   ksql:
+    enabled: true
+    url: http://ksql:9088
+   schemaRegistry:
+    enabled: true
+    url: http://schemaregistry:8081
+  ##
+  ## C3 External Access
+  ##
+  loadBalancer:
+   enabled: false
+   domain: ""
+  ##
+  ## TLS configuration
+  ##
+  tls:
+   enabled: false
+   authentication:
+    type: ""
+   fullchain: |-
+   privkey: |-
+   cacerts: |-
+  ##
+  ## C3 authentication
+  ##
+  auth:
+   basic:
+    enabled: true
+    ##
+    ## map with key as user and value as password and role
+    property:
+     admin: Developer1,Administrators
+     disallowed: no_access


### PR DESCRIPTION
The Edited Helm/Providers/private.yaml file from the Confluent Operator Fileset: Entries in the private.yaml file used for Operator installation that required edits to be done to customize the contents for the Confluent Kafka on VMware vSphere Tanzu solution.