### PR TITLE
Fix bug that prevents CPI usage in deployment mode (e.g. cluster-external)

### DIFF
--- a/charts/vsphere-cpi/Chart.yaml
+++ b/charts/vsphere-cpi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
     email: myles@vmware.com
 name: vsphere-cpi
 sources:
-version: 1.0.0
+version: 1.0.1

--- a/charts/vsphere-cpi/templates/deployment.yaml
+++ b/charts/vsphere-cpi/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             {{- if .Values.global.config.externalKubeconfig.enabled }}
             - --kubeconfig=/etc/kubernetes/value
             {{- end }}
-            {{- if gt .Values.vSphereCPI.replicaCount 1 }}
+            {{- if le (.Values.vSphereCPI.replicaCount | int) 1 }}
             - --leader-elect=false
             {{- end }}
           {{- end }}

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -13,8 +13,6 @@ global:
   ##   - myRegistryKeySecretName
   ##
   imagePullSecrets: []
-
-global:
   config:
     externalKubeconfig: 
       enabled: false


### PR DESCRIPTION
This fixes a small comparison bug that prevented running CPI as a delpoyment without leader election