### PR TITLE
update from deprecated API

### DIFF
--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: vsphere-csi
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 1.3.2
+version: 2.0.0

--- a/charts/vsphere-csi/templates/csi-driver.yaml
+++ b/charts/vsphere-csi/templates/csi-driver.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.config.csidriver.enabled -}}
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.vsphere.vmware.com


### PR DESCRIPTION
`storage.k8s.io/v1beta1` is no longer served as of K8s 1.22.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/