### PR TITLE
update CPI CR to allow CM extension-apiserver-authentication

### DIFF
--- a/charts/vsphere-cpi/templates/rbac.yaml
+++ b/charts/vsphere-cpi/templates/rbac.yaml
@@ -116,4 +116,18 @@ rules:
       - list
       - watch
       - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "common.names.fullname" . }}-controller-ex-api-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "vSphereCPI.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
CPI needs to read CM extension-apiserver-authentication. add minimal role binding to kubernetes.io/bootstrapping: rbac-defaults role in kube-system