### PR TITLE
Match secret name in webhook

### DIFF
--- a/charts/vsphere-csi/templates/snapshot-validation-webhook/deployment.yaml
+++ b/charts/vsphere-csi/templates/snapshot-validation-webhook/deployment.yaml
@@ -121,7 +121,7 @@ spec:
       volumes:
         - name: webhook-certs
           secret:
-            secretName: {{ template "common.names.fullname" . }}-webhook-certs
+            secretName: {{ template "common.names.fullname" . }}-snapshot-webhook-certs
         {{- if .Values.snapshotwebhook.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.snapshotwebhook.extraVolumes "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Seems like the snapshotwebhook deployment does not mount the correct secrets