### PR TITLE
[vsphere-csi] allow to use an existing secrets

### DIFF
--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: vsphere-csi
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.1.0
+version: 3.2.0

--- a/charts/vsphere-csi/README.md
+++ b/charts/vsphere-csi/README.md
@@ -70,12 +70,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                           | Description                                                                                                        | Value       |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `global.config.existingSecret`                 | Use existing secret for csi-vsphere.conf                                                                           | `null`      |
 | `global.config.csidriver.enabled`              | Enable CSI-Driver                                                                                                  | `true`      |
 | `global.config.storageclass.enabled`           | Enable creation of StorageClass                                                                                    | `false`     |
 | `global.config.storageclass.storagepolicyname` | Set storagePolicyName                                                                                              | `""`        |
 | `global.config.storageclass.expansion`         | Enable VolumeExpansion for storageclass, see https://vsphere-csi-driver.sigs.k8s.io/features/volume_expansion.html | `false`     |
 | `global.config.storageclass.default`           | Make created storageClass default                                                                                  | `false`     |
-| `global.config.netconfig`                      | Configre Network config for Filebased-Volumes                                                                      | `undefined` |
+| `global.config.netconfig`                      | Configure Network config for Filebased-Volumes                                                                     | `{}`        |
 
 
 ### global.config.global Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.

--- a/charts/vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/vsphere-csi/templates/controller/deployment.yaml
@@ -583,7 +583,7 @@ spec:
       volumes:
         - name: vsphere-config-volume
           secret:
-            secretName: {{ template "common.names.fullname" . }}
+            secretName: {{ default (include "common.names.fullname" .) .Values.global.config.existingSecret }}
         - name: socket-dir
           emptyDir: {}
         {{- if .Values.controller.extraVolumes }}

--- a/charts/vsphere-csi/templates/secret.yaml
+++ b/charts/vsphere-csi/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.global.mode "workload" }}
+{{- if and (ne .Values.global.mode "workload") (not .Values.global.config.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/vsphere-csi/values.yaml
+++ b/charts/vsphere-csi/values.yaml
@@ -23,6 +23,8 @@ global:
 ## @param global.config.csidriver.enabled Enable CSI-Driver
 
   config:
+## @param global.config.global.existingSecret Use existing secret for csi-vsphere.conf
+    existingSecret:
     csidriver:
       enabled: true
 ## @param global.config.storageclass.enabled Enable creation of StorageClass


### PR DESCRIPTION
Useful for GitOps.

On top of #50? Note: This is different than `secretName`/`secretNamespace`. Here we need the secret to be in the management cluster.