### PR TITLE
[vsphere-csi] Don't deploy csi-snapshotter if controller.config.block-volume-snapshot is disabled

### DIFF
--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: vsphere-csi
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.0.0
+version: 3.0.1

--- a/charts/vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/vsphere-csi/templates/controller/deployment.yaml
@@ -496,7 +496,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.controller.provisioner.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
 
-
+      {{- if (index .Values.controller.config "block-volume-snapshot" ) }}
         - name: csi-snapshotter
           image: {{ template "vsphere-csi.controller.snapshotter.image" . }}
           imagePullPolicy: {{ .Values.controller.snapshotter.image.pullPolicy }}
@@ -564,6 +564,7 @@ spec:
         {{- if .Values.controller.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.controller.sidecars "context" $) | nindent 8 }}
         {{- end }}
+      {{- end }}
       volumes:
         - name: vsphere-config-volume
           secret:

--- a/charts/vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/vsphere-csi/templates/controller/deployment.yaml
@@ -496,7 +496,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.controller.provisioner.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
 
-      {{- if (index .Values.controller.config "block-volume-snapshot" ) }}
+        {{- if (index .Values.controller.config "block-volume-snapshot" ) }}
         - name: csi-snapshotter
           image: {{ template "vsphere-csi.controller.snapshotter.image" . }}
           imagePullPolicy: {{ .Values.controller.snapshotter.image.pullPolicy }}
@@ -564,7 +564,7 @@ spec:
         {{- if .Values.controller.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.controller.sidecars "context" $) | nindent 8 }}
         {{- end }}
-      {{- end }}
+        {{- end }}
       volumes:
         - name: vsphere-config-volume
           secret:


### PR DESCRIPTION
Fixes #60 