### PR TITLE
feat: remove default nodeSelector and tolerations from values file

### DIFF
--- a/charts/vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/vsphere-csi/templates/controller/deployment.yaml
@@ -53,9 +53,20 @@ spec:
       {{- end }}
       {{- if .Values.controller.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.controller.nodeSelector "context" $) | nindent 8 }}
+      {{- else }}
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
       {{- end }}
       {{- if .Values.controller.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.controller.tolerations "context" .) | nindent 8 }}
+      {{- else }}
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
       {{- end }}
       {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName | quote }}

--- a/charts/vsphere-csi/values.yaml
+++ b/charts/vsphere-csi/values.yaml
@@ -1121,23 +1121,25 @@ controller:
   affinity: {}
   ## @param controller.nodeSelector Node labels for controller pods assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
-  ##
-  nodeSelector:
+  ## e.g:
+  ## nodeSelector:
+  ##   node-role.kubernetes.io/control-plane: ""
+  nodeSelector: {}
   ## @skip controller.nodeSelector.node-role.kubernetes.io/master
   ## @skip "controller.nodeSelector.node-role.kubernetes.io/master"
   ## @skip controller.nodeSelector.node-role.kubernetes.io\/master
-
-    node-role.kubernetes.io/control-plane: ""
+    
   ## @param controller.tolerations Tolerations for controller pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  ##
-  tolerations:
-    - key: node-role.kubernetes.io/control-plane
-      operator: Exists
-      effect: NoSchedule
-    - key: node-role.kubernetes.io/master
-      operator: Exists
-      effect: NoSchedule
+  ## e.g:
+  ## tolerations:
+  ##   - key: node-role.kubernetes.io/control-plane
+  ##     operator: Exists
+  ##     effect: NoSchedule
+  ##   - key: node-role.kubernetes.io/master
+  ##     operator: Exists
+  ##     effect: NoSchedule
+  tolerations: []
   ## @param controller.updateStrategy.type controller statefulset strategy type
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##


### PR DESCRIPTION
Hello!

First of all thanks for making those charts, they're very helpful to the community!

I would like to propose an improvement about the scheduling of the CSI controller.
For now it is only schedulable on control plane nodes, but in our case we're making use of dedicated infrastructure nodes whose role is to run those kind of controllers.

I've tried adding a nodeSelector and tolerations -- however the nodeSelector being a map, the key for the control plane never gets deleted -- and the controller pod remains in Pending state forever. Ideally we would need to rely _only_ on nodeSelector and tolerations provided by the user when they're provided, otherwise use the defaults you guys have setup -- but not a mix of both.

I hope my intend is clear, let me know if you have any remarks.

Fred
