### PR TITLE
Template DRIVER_REG_SOCK_PATH for Node Registrar

### DIFF
--- a/charts/vsphere-csi/templates/node/daemonset-linux.yaml
+++ b/charts/vsphere-csi/templates/node/daemonset-linux.yaml
@@ -84,7 +84,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+              value: {{ .Values.linuxnode.kubelet.linuxPath }}/plugins/csi.vsphere.vmware.com/csi.sock
             {{- if .Values.node.registrar.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.node.registrar.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
This small PR is to enable the node registrar to work if the user has set `linuxnode.kubelet.linuxPath` to a different path, i.e. _not_ `/var/lib/kubelet`.