### PR TITLE
Fix various spelling mistakes made in values.yaml & README.md.

### DIFF
--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -23,7 +23,7 @@ global:
       type: Secret # or ConfigMap
       name: vsphere-cpi
     secretsInline: true
-    # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    # Global properties in this section will be used for all specified vCenters unless overridden in VirtualCenter section.
     # global:
     #   port: 443
     #   # set insecureFlag to true if the vCenter uses a self-signed cert

--- a/charts/vsphere-csi-old/README.md
+++ b/charts/vsphere-csi-old/README.md
@@ -91,7 +91,7 @@ If your Kubernetes clusters are in a network that is firewalled from the Interne
 
 ## Manually installing the vSphere CSI driver
 
-If you want to provide your own `csi-vsphere.conf`, for example, to handle multple datacenters/vCenters or for using zones, you can learn how to manually deploy the CSI driver by reading the following [documentation](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html).
+If you want to provide your own `csi-vsphere.conf`, for example, to handle multiple datacenters/vCenters or for using zones, you can learn how to manually deploy the CSI driver by reading the following [documentation](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/installation.html).
 
 ## Uninstalling the vSphere CSI Helm Chart
 

--- a/charts/vsphere-csi/README.md
+++ b/charts/vsphere-csi/README.md
@@ -77,15 +77,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.config.storageclass.expansion`         | Enable VolumeExpansion for storageclass, see https://vsphere-csi-driver.sigs.k8s.io/features/volume_expansion.html | `false`       |
 | `global.config.storageclass.default`           | Make created storageClass default                                                                                  | `false`       |
 | `global.config.storageclass.reclaimPolicy`     | Set reclaimPolicy for storageclass                                                                                 | `Delete`      |
-| `global.config.netconfig`                      | Configre Network config for Filebased-Volumes                                                                      | `{}`          |
+| `global.config.netconfig`                      | Configure Network config for Filebased-Volumes                                                                      | `{}`          |
 
-### global.config.global Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+### global.config.global Global properties in this section will be used for all specified vCenters unless overridden in VirtualCenter section.
 
 | Name                                 | Description                                                       | Value  |
 | ------------------------------------ | ----------------------------------------------------------------- | ------ |
 | `global.config.global.port`          | Default port to use if not specified different for vCenter        | `443`  |
 | `global.config.global.insecure-flag` | Whether to default to insecure connections to vCenters by default | `true` |
-| `global.config.vcenter`              | vCenter-specifc confguration                                      | `{}`   |
+| `global.config.vcenter`              | vCenter-specific configuration                                    | `{}`   |
 | `global.config.labels`               | Used to configure Toplogy-awareness                               | `{}`   |
 
 ### Common parameters

--- a/charts/vsphere-csi/values.yaml
+++ b/charts/vsphere-csi/values.yaml
@@ -41,7 +41,7 @@ global:
       expansion: false # https://vsphere-csi-driver.sigs.k8s.io/features/volume_expansion.html
       default: false
       reclaimPolicy: Delete
-## @param global.config.netconfig Configre Network config for Filebased-Volumes
+## @param global.config.netconfig Configure Network config for Filebased-Volumes
 
     netconfig: {}
       # A:
@@ -50,9 +50,9 @@ global:
       #   permissions: "READ_WRITE"
       #   rootsquash: true
       #   datastore: "datastore"
-## @section global.config.global Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+## @section global.config.global Global properties in this section will be used for all specified vCenters unless overridden in VirtualCenter section.
 
-    # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    # Global properties in this section will be used for all specified vCenters unless overridden in VirtualCenter section.
     global:
 ## @param global.config.global.port Default port to use if not specified different for vCenter
 ## @param global.config.global.insecure-flag Whether to default to insecure connections to vCenters by default
@@ -65,7 +65,7 @@ global:
       #secretNamespace: kube-system
       #cluster-id: your-unique-cluster-id
     # vcenter section
-## @param global.config.vcenter vCenter-specifc confguration
+## @param global.config.vcenter vCenter-specific configuration
 
     vcenter: {}
       # your-vcenter-name-here:


### PR DESCRIPTION
These changes fix various spelling mistakes made in the project's `values.yaml` & `README.md`.

* In `charts/vsphere-cpi/values.yaml`, `overriden` has been corrected to `overridden`.
* In `charts/vsphere-csi-old/README.md`, `multple` has been corrected to `multiple`.
* In `charts/vsphere-csi/README.md`, several changes has been changed:
  * `Configre` has been corrected to `Configure`.
  * `overriden` has been corrected to `overridden`.
  * `specifc confguration` has been corrected to `specific configuration`.
* In `charts/vsphere-csi/values.yaml`,  several changes has been changed:
  * `overriden` has been corrected to `overridden`.
  * `specifc confguration` has been corrected to `specific configuration`.