### PR TITLE
Moving hardcoded nodeSelector of node/daemonset-linux to helm function, making node.nodeSelector usable

### DIFF
--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: vsphere-csi
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.5.0
+version: 3.5.1

--- a/charts/vsphere-csi/templates/node/daemonset-linux.yaml
+++ b/charts/vsphere-csi/templates/node/daemonset-linux.yaml
@@ -30,8 +30,6 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.node.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
-      nodeSelector:
-        kubernetes.io/os: linux
       serviceAccountName: {{ template "vsphere-csi.node.serviceAccountName" . }}
       {{- include "vsphere-csi.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.node.dnsPolicy }}
@@ -50,6 +48,10 @@ spec:
       {{- end }}
       {{- if .Values.node.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.node.nodeSelector "context" $) | nindent 8 }}
+        kubernetes.io/os: linux
+      {{- else }}
+      nodeSelector:
+        kubernetes.io/os: linux
       {{- end }}
       {{- if .Values.node.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.node.tolerations "context" .) | nindent 8 }}


### PR DESCRIPTION
## Description

This PR makes node.nodeSelector usable again by moving the hardcoded nodeSelector of daemonset-linux.yaml to the node.nodeSelector function. 

## Issue

If `node.nodeSelector` is currently set, the produced templated yaml contains 2 nodeSelector entries, resulting in errors during apply.

After using helm template and applying the result, we got this following error:

```
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 64: mapping key "nodeSelector" already defined at line 44
error: no objects passed to apply
```
