### PR TITLE
Add datastore as a configurable parameter on the StorageClass.

### DIFF
--- a/charts/vsphere-csi/templates/storageclass.yaml
+++ b/charts/vsphere-csi/templates/storageclass.yaml
@@ -10,9 +10,14 @@ metadata:
 {{- end }}
 
 provisioner: csi.vsphere.vmware.com
-{{- if .Values.global.config.storageclass.storagepolicyname }}
+{{- if or (.Values.global.config.storageclass.storagepolicyname) (.Values.global.config.storageclass.datastore) }}
 parameters:
+  {{- if .Values.global.config.storageclass.storagepolicyname }}
   storagepolicyname: {{ .Values.global.config.storageclass.storagepolicyname }}
+  {{- end -}}
+  {{- if .Values.global.config.storageclass.datastore }}
+  datastore: {{ .Values.global.config.storageclass.datastore }}
+  {{- end -}}
 {{- end -}}
 {{- if .Values.global.config.storageclass.expansion }}
 allowVolumeExpansion: true

--- a/charts/vsphere-csi/values.yaml
+++ b/charts/vsphere-csi/values.yaml
@@ -30,6 +30,7 @@ global:
 ## @param global.config.storageclass.enabled Enable creation of StorageClass
 ## @param global.config.storageclass.name Set storageClass name
 ## @param global.config.storageclass.storagepolicyname Set storagePolicyName
+## @param global.config.storageclass.datastore Set datastore
 ## @param global.config.storageclass.expansion Enable VolumeExpansion for storageclass, see https://vsphere-csi-driver.sigs.k8s.io/features/volume_expansion.html
 ## @param global.config.storageclass.default Make created storageClass default
 ## @param global.config.storageclass.reclaimPolicy Set reclaimPolicy for storageclass
@@ -38,6 +39,7 @@ global:
       enabled: false
       name: "vsphere-csi"
       storagepolicyname: ""
+      datastore: ""
       expansion: false # https://vsphere-csi-driver.sigs.k8s.io/features/volume_expansion.html
       default: false
       reclaimPolicy: Delete


### PR DESCRIPTION
Adding the ability to configure the datastore parameter on the StorageClass.

I contemplated replacing storageclass.storagepolicyname with a map of just parameters that would be injected but decided not to as it would be a breaking change to the chart.