### PR TITLE
Switch image registry from gcr.io to registry.k8s.io.

### DIFF
--- a/charts/vsphere-cpi/Chart.yaml
+++ b/charts/vsphere-cpi/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: cpi
 apiVersion: v2
-appVersion: v1.25.1
+appVersion: v1.28.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -21,4 +21,4 @@ maintainers:
     email: myles@vmware.com
 name: vsphere-cpi
 sources:
-version: 1.5.1
+version: 1.6.0

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -91,9 +91,9 @@ vSphereCPI:
   ## @param vSphereCPI.image.debug Enable image debug mode
   ##
   image:
-    registry: gcr.io
-    repository: cloud-provider-vsphere/cpi/release/manager
-    tag: v1.25.1
+    registry: registry.k8s.io
+    repository: cloud-pv-vsphere/cloud-provider-vsphere
+    tag: v1.28.0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -1,6 +1,6 @@
 
 apiVersion: v2
-appVersion: 3.3.0
+appVersion: 3.3.1
 dependencies:
   - condition: snapshot.controller.enabled
     name: snapshot-controller
@@ -35,4 +35,4 @@ maintainers:
 name: vsphere-csi
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.6.0
+version: 3.7.0

--- a/charts/vsphere-csi/values.yaml
+++ b/charts/vsphere-csi/values.yaml
@@ -182,9 +182,9 @@ controller:
   ## @param controller.image.debug Enable image debug mode
   ##
   image:
-    registry: gcr.io
-    repository: cloud-provider-vsphere/csi/release/driver
-    tag: v3.3.0
+    registry: registry.k8s.io
+    repository: csi-vsphere/driver
+    tag: v3.3.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -610,9 +610,9 @@ controller:
   ## @param controller.syncer.image.debug Enable image debug mode
   ##
     image:
-      registry: gcr.io
-      repository: cloud-provider-vsphere/csi/release/syncer
-      tag: v3.3.0
+      registry: registry.k8s.io
+      repository: csi-vsphere/syncer
+      tag: v3.3.1
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1460,9 +1460,9 @@ node:
   ##
 
   image:
-    registry: gcr.io
-    repository: cloud-provider-vsphere/csi/release/driver
-    tag: v3.3.0
+    registry: registry.k8s.io
+    repository: csi-vsphere/driver
+    tag: v3.3.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1952,9 +1952,9 @@ winnode:
   ##
 
   image:
-    registry: gcr.io
-    repository: cloud-provider-vsphere/csi/release/driver
-    tag: v3.3.0
+    registry: registry.k8s.io
+    repository: csi-vsphere/driver
+    tag: v3.3.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2451,9 +2451,9 @@ webhook:
   ##
 
   image:
-    registry: gcr.io
-    repository: cloud-provider-vsphere/csi/release/syncer
-    tag: v3.3.0
+    registry: registry.k8s.io
+    repository: csi-vsphere/syncer
+    tag: v3.3.1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
The vSphere CSI & CPI images are no longer available via gcr.io, instead they are now published on registry.k8s.io. I have updated the values for the CSI & CPI charts to point to the new registry.

See the following for details:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/3053
 - https://github.com/kubernetes/cloud-provider-vsphere?tab=readme-ov-file#container-images
