### PR TITLE
fix: use correct indentation in linux daemonset for extravolumes 

### DIFF
--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: vsphere-csi
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.7.2
+version: 3.7.3

--- a/charts/vsphere-csi/templates/node/daemonset-linux.yaml
+++ b/charts/vsphere-csi/templates/node/daemonset-linux.yaml
@@ -279,6 +279,6 @@ spec:
           path: /sys/devices
           type: Directory
         {{- if .Values.node.extraVolumes }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.node.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.node.extraVolumes "context" $) | nindent 6 }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
Closes https://github.com/vsphere-tmm/helm-charts/issues/91