### PR TITLE
chore: make provisioner compatible

### DIFF
--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: vsphere-csi
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.7.5
+version: 3.7.6

--- a/charts/vsphere-csi/values.yaml
+++ b/charts/vsphere-csi/values.yaml
@@ -738,7 +738,7 @@ controller:
     image:
       registry: registry.k8s.io
       repository: sig-storage/csi-provisioner
-      tag: v5.2.0
+      tag: v4.0.1
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Hey @MaxRink 

Seems like the latest csi-provisionier is not yet compatible. I cannot find a compatibility matrix anywhere but downgrading to the previous version works fine