### PR TITLE
fix: use value of service.annotations in service template

### DIFF
--- a/charts/vsphere-csi/Chart.lock
+++ b/charts/vsphere-csi/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.6.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
-digest: sha256:7595bfdc2174f621a04750e36d6515b777adb4be26a7897058da8ae5cd909ee7
-generated: "2024-10-29T10:07:30.262650493-04:00"
+  version: 2.31.1
+digest: sha256:42a94d69e7ad1ee21bfd833f23d234dd05ec1bb5e22b37793f5fe61586eb39ef
+generated: "2025-06-05T13:46:51.478541361+02:00"

--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -15,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: A Helm chart for vSphere CSI Driver
-engine: gotpl
 home: https://github.com/kubernetes-sigs/vsphere-csi-driver
 icon: https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/docs/images/vmware_logo.png
 keywords:

--- a/charts/vsphere-csi/Chart.yaml
+++ b/charts/vsphere-csi/Chart.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v2
 appVersion: 3.3.1
 dependencies:
@@ -14,7 +13,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: A Helm chart for vSphere CSI Driver
 engine: gotpl
 home: https://github.com/kubernetes-sigs/vsphere-csi-driver
@@ -31,4 +30,4 @@ maintainers:
 name: vsphere-csi
 sources:
   - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.7.6
+version: 3.7.7

--- a/charts/vsphere-csi/templates/controller/service.yaml
+++ b/charts/vsphere-csi/templates/controller/service.yaml
@@ -9,8 +9,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.service.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
The `service.annotations` value was never used. This fixes it. I also updated bitnami-common such that I could use the merge function. `service.annotations` has precedence over the common annotations.

Also includes small deprecation fix for helm 3.